### PR TITLE
Adds ability to determine gradient (edge) orientation

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -10,12 +10,17 @@ Depth = 3
 ```@docs
 detect_edges
 detect_edges!
+detect_subpixel_edges
+detect_subpixel_edges!
+detect_gradient_orientation
+detect_gradient_orientation!
 thin_edges
 thin_edges!
+thin_subpixel_edges
+thin_subpixel_edges!
 ```
 
 ## Edge Detection Algorithms
-
 ```@docs
 ImageEdgeDetection.EdgeDetectionAPI.AbstractEdgeDetectionAlgorithm
 ```
@@ -26,7 +31,6 @@ ImageEdgeDetection.Canny
 ```
 
 ## Edge Thinning Algorithms
-
 ```@docs
 ImageEdgeDetection.EdgeDetectionAPI.AbstractEdgeThinningAlgorithm
 ```
@@ -38,7 +42,12 @@ ImageEdgeDetection.NonmaximaSuppression
 
 ### Non-maxima Suppression (Subpixel)
 ```@docs
-ImageEdgeDetection.NonmaximaSubpixelSuppression
+ImageEdgeDetection.SubpixelNonmaximaSuppression
+```
+
+### OrientationConvention
+```@docs
+ImageEdgeDetection.OrientationConvention
 ```
 
 ## Supplementary Types

--- a/src/ImageEdgeDetection.jl
+++ b/src/ImageEdgeDetection.jl
@@ -18,9 +18,9 @@ import .EdgeDetectionAPI: AbstractEdgeDetectionAlgorithm,
                           detect_edges, detect_edges!,
                           detect_subpixel_edges, detect_subpixel_edges!
 
- import .EdgeDetectionAPI: AbstractEdgeThinningAlgorithm,
-                           thin_edges, thin_edges!,
-                           thin_subpixel_edges, thin_subpixel_edges!
+import .EdgeDetectionAPI: AbstractEdgeThinningAlgorithm,
+                          thin_edges, thin_edges!,
+                          thin_subpixel_edges, thin_subpixel_edges!
 
 # TODO Relax this to all image color types
 const GenericGrayImage = AbstractArray{<:Union{Number, AbstractGray}}
@@ -39,6 +39,7 @@ end
 include("algorithms/nonmaxima_suppression.jl")
 include("algorithms/subpixel_nonmaxima_suppression.jl")
 include("algorithms/canny.jl")
+include("algorithms/gradient_orientation.jl")
 
 # Set the Canny algorithm as the default edge detection algorithm.
 detect_edges(img::AbstractArray,
@@ -53,6 +54,7 @@ export
     Canny,
     NonmaximaSuppression,
     SubpixelNonmaximaSuppression,
+    OrientationConvention,
     Percentile,
     thin_edges,
     thin_edges!,
@@ -61,6 +63,8 @@ export
     detect_edges,
     detect_edges!,
     detect_subpixel_edges,
-    detect_subpixel_edges!
+    detect_subpixel_edges!,
+    detect_gradient_orientation,
+    detect_gradient_orientation!
 
 end # module

--- a/src/algorithms/gradient_orientation.jl
+++ b/src/algorithms/gradient_orientation.jl
@@ -1,0 +1,204 @@
+"""
+```
+    OrientationConvention(; compass_direction::AbstractChar = 'S', is_clockwise::Bool = false, in_radians = true, tol = sqrt(eps(Float64)))
+```
+Specifies the coordinate system context for `detect_gradient_orientation` which
+determines the meaning of the angles (the gradient orientations).
+
+# Details
+
+You can specify how you want the gradient orientation to be reported.  By
+default, the orientation is measured counter-clockwise from the south direction.
+This is because in a Raster coordinate system, the first spatial dimension
+increases as one goes down the image (i.e. it points south), and the second
+spatial dimension increases as one moves to the right of the image (i.e. it
+points east).
+
+If you wish to interpret the orientation in a canonical Cartesian coordinate
+convention you would specify east as the reference compass direction
+(`compass_direction = 'E'`) and a counter-clockwise direction (`clockwise =
+false`).
+
+If `in_radians = true` the valid angles are reported in the range of `[0...2π)`,
+otherwise they are reported in the range `[0...360)`. The values `2π` and `360`
+are used as sentinels to designate undefined angles (because the gradient
+magnitude was too close to zero). By default, an angle is undefined if `(abs(g₁)
+< tol && abs(g₂) < tol)` where `g₁` and `g₂` denote the gradient in the first
+and second spatial dimensions, and `tol = sqrt(eps(Float64))`.
+
+# Example
+
+```julia
+
+using TestImages, FileIO, ImageView, ImageEdgeDetection, ImageFiltering
+
+img =  testimage("mandril_gray")
+
+# Gradient in the first and second spatial dimension
+g₁, g₂ = imgradients(img, KernelFactors.scharr)
+
+# Interpret the angles with respect to a canonical Cartesian coordinate system
+# where the angles are measured counter-clockwise from the positive x-axis.
+
+orientation_convention = OrientationConvention(in_radians = true,
+                                               is_clockwise = false,
+                                               compass_direction = 'E')
+angles = detect_gradient_orientation(g₁, g₂, orientation_convention)
+
+```
+"""
+@with_kw struct OrientationConvention{ T <: AbstractChar}
+    # 'N', 'S', 'E ', 'W' for (north, south, east, west)
+    compass_direction::T = 'S'
+    is_clockwise::Bool = false
+    in_radians::Bool = true
+    tol = sqrt(eps(eltype(Float64)))
+end
+
+
+"""
+    detect_gradient_orientation(g₁::AbstractArray, g₂::AbstractArray, orientation_convention::OrientationConvention, args...; kwargs...)
+
+Given the gradient in the first (`g₁`) and second (`g₂`) spatial dimensions,
+returns the gradient orientation, where the orientation is interpreted according
+to a supplied [`OrientationConvention`](@ref
+ImageEdgeDetection.OrientationConvention).
+
+# Details
+
+You can specify how you want the gradient orientation to be reported by
+supplying an [`OrientationConvention`](@ref
+ImageEdgeDetection.OrientationConvention). If left unspecified the orientation
+is measured counter-clockwise from the south direction. This is because in a
+Raster coordinate system, the first spatial dimension increases as one goes down
+the image (i.e. it points south), and the second spatial dimension increases as
+one moves to the right of the image (i.e. it points east).
+
+If you wish to interpret the orientation in a canonical Cartesian coordinate
+convention you would specify east as the reference compass direction
+(`compass_direction = 'E'`) and a counter-clockwise direction (`clockwise =
+false`).
+
+# Output
+
+Returns a two-dimensional array of angles. If `in_radians = true` the valid
+angles are reported in the range of `[0...2π)`, otherwise they are reported in
+the range `[0...360)`. The values `2π` and `360` are used as sentinels to
+designate undefined angles (because the gradient magnitude was too close to
+zero). By default, an angle is undefined if `(abs(g₁) < tol && abs(g₂) < tol)`
+where `g₁` and `g₂` denote the gradient in the first and second spatial
+dimensions, and `tol = sqrt(eps(Float64))` (as defined in
+[`OrientationConvention`](@ref ImageEdgeDetection.OrientationConvention)).
+
+
+See also: [`detect_gradient_orientation!`](@ref)
+"""
+function detect_gradient_orientation(g₁::AbstractArray, g₂::AbstractArray, orientation_convention::OrientationConvention)
+    out = zeros(axes(g₁))
+    detect_gradient_orientation!(out, g₁, g₂, orientation_convention)
+    return out
+end
+
+function detect_gradient_orientation(g₁::AbstractArray, g₂::AbstractArray)
+    out = zeros(axes(g₁))
+    detect_gradient_orientation!(out, g₁, g₂, OrientationConvention())
+    return out
+end
+
+"""
+    detect_gradient_orientation(out::AbstractArray, g₁::AbstractArray, g₂::AbstractArray, orientation_convention::OrientationConvention, args...; kwargs...)
+
+Given the gradient in the first (`g₁`) and second (`g₂`) spatial dimensions,
+returns the gradient orientation in `out`, where the orientation is interpreted
+according to a supplied [`OrientationConvention`](@ref
+ImageEdgeDetection.OrientationConvention).
+
+# Details
+
+You can specify how you want the gradient orientation to be reported by
+supplying an [`OrientationConvention`](@ref
+ImageEdgeDetection.OrientationConvention). If left unspecified the orientation
+is measured counter-clockwise in radians from the south direction. This is
+because in a Raster coordinate system, the first spatial dimension increases as
+one goes down the image (i.e. it points south), and the second spatial dimension
+increases as one moves to the right of the image (i.e. it points east).
+
+If you wish to interpret the orientation in a canonical Cartesian coordinate
+convention you would specify east as the reference compass direction
+(`compass_direction = 'E'`) and a counter-clockwise direction (`clockwise =
+false`).
+
+# Output
+
+Returns a two-dimensional array of angles. If `in_radians = true` genuine angles are
+reported in the range of `[0...2π)`, otherwise they are reported in the range
+`[0...360)`. The values `2π` and `360` are used as sentinels to designate
+undefined angles (because the gradient magnitude was too close to zero).
+By default, an angle is undefined if `(abs(g₁) < tol && abs(g₂) < tol)` where
+`g₁` and `g₂` denote the gradient in the first and second spatial dimensions,
+and `tol = sqrt(eps(eltype(out)))` (as defined in [`OrientationConvention`](@ref
+ImageEdgeDetection.OrientationConvention)).
+
+See also: [`detect_gradient_orientation`](@ref)
+"""
+function detect_gradient_orientation!(out::AbstractArray, g₁::AbstractArray, g₂::AbstractArray, orientation_convention::OrientationConvention)
+    @unpack compass_direction, is_clockwise, in_radians = orientation_convention
+    tol = sqrt(eps(eltype(out)))
+
+    # Determine from which compass direction we intend to measure the angle.
+    if compass_direction == 'S' || compass_direction == 's'
+        offset = π/2
+    elseif compass_direction == 'E' || compass_direction == 'e'
+        offset = 0.0
+    elseif compass_direction == 'N' || compass_direction == 'n'
+        offset = -π/2
+    elseif compass_direction == 'W' || compass_direction == 'w'
+        offset = π
+    else
+        @warn("Unrecognised compass_direction... using a default direction of south (S).")
+        offset = π/2
+    end
+
+
+    if !is_clockwise && !in_radians
+        @inbounds for i in CartesianIndices(g₁)
+            out[i] = rad2deg(zero_to_2PI(valid_angle(g₁[i], g₂[i], offset, tol)))
+        end
+    elseif !is_clockwise && in_radians
+        @inbounds for i in CartesianIndices(g₁)
+            out[i] = zero_to_2PI(valid_angle(g₁[i], g₂[i], offset, tol))
+        end
+    elseif is_clockwise && !in_radians
+        @inbounds for i in CartesianIndices(g₁)
+            out[i] = rad2deg(zero_to_2PI(clockwise(valid_angle(g₁[i], g₂[i], offset, tol))))
+        end
+    elseif is_clockwise && in_radians
+        @inbounds for i in CartesianIndices(g₁)
+            out[i] = zero_to_2PI(clockwise(valid_angle(g₁[i], g₂[i], offset, tol)))
+        end
+    end
+    return nothing
+end
+
+function detect_gradient_orientation!(out::AbstractArray, g₁::AbstractArray, g₂::AbstractArray)
+    detect_gradient_orientation!(out, g₁, g₂, OrientationConvention())
+    return out
+end
+
+# When the angle is undefined because g₁ and g₂ are almost zero, we return
+# a "dummy" value of 2π.
+function valid_angle(g₁, g₂, offset, tol)
+    # The expression for the angle when changing coordinate system from Raster
+    # to Cartesian coordinates is atan(-g₁, g₂). The offset is used to indicate
+    # against which compass direction we will measure angles.
+    is_angle_undefined = (abs(g₁) < tol && abs(g₂) < tol)
+    return  is_angle_undefined ? 2π : atan(-g₁, g₂) + offset
+end
+
+function zero_to_2PI(θ)
+   return (θ >= 0 ? θ : (2*π + θ))
+end
+
+function clockwise(x)
+   return mod(-x, 2π)
+end

--- a/src/algorithms/subpixel_nonmaxima_suppression.jl
+++ b/src/algorithms/subpixel_nonmaxima_suppression.jl
@@ -54,7 +54,7 @@ imshow(nms)
 1. J. Canny, "A Computational Approach to Edge Detection," in IEEE Transactions on Pattern Analysis and Machine Intelligence, vol. PAMI-8, no. 6, pp. 679-698, Nov. 1986, doi: 10.1109/TPAMI.1986.4767851.
 2. F. Devernay, "A non-maxima suppression method for edge detection with sub-pixel accuracy", Tech. Report RR-2724, INRIA, 1995.
 """
-@with_kw struct SubpixelNonmaximaSuppression{ T <: Union{Real,AbstractGray, Percentile}} <: AbstractEdgeThinningAlgorithm
+@with_kw struct SubpixelNonmaximaSuppression{T <: Union{Real,AbstractGray, Percentile}} <: AbstractEdgeThinningAlgorithm
     threshold::T = Percentile(20)
 end
 

--- a/test/algorithms/gradient_orientation.jl
+++ b/test/algorithms/gradient_orientation.jl
@@ -1,0 +1,128 @@
+@testset "detect_gradient_orientation" begin
+    @info "Test: detect_gradient_orientation"
+
+    @testset "Numerical" begin
+        # Points on a compass in the sequence: E, NE, N, NW, W, SW, S, SE
+        # expressed in raster coordinates (increasing rows, increasing columns)
+        g₁ = [0, -1, -1, -1, 0, 1, 1, 1]
+        g₂ = [1, 1, 0, -1, -1, -1, 0, 1]
+
+        # Measuring from East in counter-clockwise manner in degrees.
+        orientation_convention = OrientationConvention(in_radians = false,
+                                                       is_clockwise = false,
+                                                       compass_direction = 'E')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== [0.0,  45.0,  90.0,  135.0,  180.0,  225.0,  270.0,  315.0])
+
+
+        # Measuring from East in counter-clockwise manner in radians.
+        orientation_convention = OrientationConvention(in_radians = true,
+                                                       is_clockwise = false,
+                                                       compass_direction = 'E')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== deg2rad.([0.0,  45.0,  90.0,  135.0,  180.0,  225.0,  270.0,  315.0]))
+
+        # Measuring from South in counter-clockwise manner in degrees.
+        orientation_convention = OrientationConvention(in_radians = false,
+                                                       is_clockwise = false,
+                                                       compass_direction = 'S')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== [90.0,  135.0,  180.0,  225.0,  270.0,  315.0,  0.0,  45.0])
+
+        # Measuring from South in counter-clockwise manner in radians.
+        orientation_convention = OrientationConvention(in_radians = true,
+                                                       is_clockwise = false,
+                                                       compass_direction = 'S')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== deg2rad.([90.0,  135.0,  180.0,  225.0,  270.0,  315.0,  0.0,  45.0]))
+
+        # Measuring from West in counter-clockwise manner in degrees.
+        orientation_convention = OrientationConvention(in_radians = false,
+                                                       is_clockwise = false,
+                                                       compass_direction = 'W')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== [180.0,  225.0,  270.0,  315.0,  360.0,  45.0,  90.0,  135.0])
+
+        # Measuring from West in counter-clockwise manner in radians.
+        orientation_convention = OrientationConvention(in_radians = true,
+                                                       is_clockwise = false,
+                                                       compass_direction = 'W')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== deg2rad.([180.0,  225.0,  270.0,  315.0,  360.0,  45.0,  90.0,  135.0]))
+
+        # Measuring from N in counter-clockwise manner degrees.
+        orientation_convention = OrientationConvention(in_radians = false,
+                                                       is_clockwise = false,
+                                                       compass_direction = 'N')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== [270.0,  315.0,  0.0,  45.0,  90.0,  135.0,  180.0,  225.0])
+
+        # Measuring from N in counter-clockwise manner in radians.
+        orientation_convention = OrientationConvention(in_radians = true,
+                                                       is_clockwise = false,
+                                                       compass_direction = 'N')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== deg2rad.([270.0,  315.0,  0.0,  45.0,  90.0,  135.0,  180.0,  225.0]))
+
+        # Measuring from East in clockwise manner.
+        orientation_convention = OrientationConvention(in_radians = false,
+                                                       is_clockwise = true,
+                                                       compass_direction = 'E')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== [0.0,  315.0,  270.0,  225.0,  180.0,  135.0,  90.0,  45.0])
+
+        # Measuring from East in clockwise manner.
+        orientation_convention = OrientationConvention(in_radians = true,
+                                                       is_clockwise = true,
+                                                       compass_direction = 'E')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== deg2rad.([0.0,  315.0,  270.0,  225.0,  180.0,  135.0,  90.0,  45.0]))
+
+        # Measuring from South in clockwise manner in degrees.
+        orientation_convention = OrientationConvention(in_radians = false,
+                                                       is_clockwise = true,
+                                                       compass_direction = 'S')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== [270.0,  225.0,  180.0,  135.0,  90.0,  45.0,  0.0,  315.0])
+
+        # Measuring from South in clockwise manner in radians.
+        orientation_convention = OrientationConvention(in_radians = true,
+                                                       is_clockwise = true,
+                                                       compass_direction = 'S')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== deg2rad.([270.0,  225.0,  180.0,  135.0,  90.0,  45.0,  0.0,  315.0]))
+
+        # Measuring from West in clockwise manner in degrees.
+        orientation_convention = OrientationConvention(in_radians = false,
+                                                       is_clockwise = true,
+                                                       compass_direction = 'W')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== [180.0,  135.0,  90.0,  45.0,  0.0,  315.0,  270.0,  225.0])
+
+        # Measuring from West in clockwise manner in radians.
+        orientation_convention = OrientationConvention(in_radians = true,
+                                                       is_clockwise = true,
+                                                       compass_direction = 'W')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== deg2rad.([180.0,  135.0,  90.0,  45.0,  0.0,  315.0,  270.0,  225.0]))
+
+        # Measuring from North in clockwise manner in degrees.
+        orientation_convention = OrientationConvention(in_radians = false,
+                                                       is_clockwise = true,
+                                                       compass_direction = 'N')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== [90.0,  45.0,  0.0,  315.0,  270.0,  225.0,  180.0,  135.0])
+
+        # Measuring from North in clockwise manner in radians.
+        orientation_convention = OrientationConvention(in_radians = true,
+                                                       is_clockwise = true,
+                                                       compass_direction = 'N')
+        out = detect_gradient_orientation(g₁, g₂, orientation_convention)
+        @test all(out .== deg2rad.([90.0,  45.0,  0.0,  315.0,  270.0,  225.0,  180.0,  135.0]))
+
+        # Verify default setting.
+        # Measuring from South in counter-clockwise manner in radians.
+        out = detect_gradient_orientation(g₁, g₂)
+        @test all(out .== deg2rad.([90.0,  135.0,  180.0,  225.0,  270.0,  315.0,  0.0,  45.0]))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ include("testutils.jl")
     include("algorithms/thin_subpixel_edges.jl")
     include("algorithms/nonmaxima_suppression.jl")
     include("algorithms/subpixel_nonmaxima_suppression.jl")
+    include("algorithms/gradient_orientation.jl")
 end
 
 nothing


### PR DESCRIPTION
This pull-requests adds the ability to determine the gradient orientation in a flexible manner. One can specify the compass direction (north, east, south, west) against which one wishes to measure the angles, and whether one is measuring in a clockwise or counter-clockwise manner. This capability should address the limitations identified in this issue: https://github.com/JuliaImages/Images.jl/issues/867

Still need to add a few more tests and finish documenting the functions. 