### PR TITLE
Ensure real values are used in interpolation

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
 
 jobs:
   test:
@@ -30,7 +28,7 @@ jobs:
         env:
           cache-name: cache-artifacts
         with:
-          path: ~/.julia/artifacts 
+          path: ~/.julia/artifacts
           key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
             ${{ runner.os }}-test-${{ env.cache-name }}-

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageEdgeDetection"
 uuid = "2b14c160-480b-11ea-1b58-656063328ff7"
 authors = ["Dr. Zygmunt L. Szpak"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"

--- a/src/algorithms/nonmaxima_suppression.jl
+++ b/src/algorithms/nonmaxima_suppression.jl
@@ -77,8 +77,8 @@ function suppress_non_maxima!(out::AbstractArray, mag::AbstractArray, g₁::Abst
     m₂ = zero(eltype(mag))
     @inbounds for i in CartesianIndices(mag)
         r, c = i.I
-        d₁ = g₁[i]
-        d₂ = g₂[i]
+        d₁ = gray(g₁[i])
+        d₂ = gray(g₂[i])
         mc = mag[i]
         if mc < threshold || mc == 0 || isnan(mc)
             out[r,c] = zero(eltype(mag))

--- a/src/algorithms/subpixel_nonmaxima_suppression.jl
+++ b/src/algorithms/subpixel_nonmaxima_suppression.jl
@@ -86,8 +86,8 @@ function suppress_subpixel_non_maxima!(out₁::AbstractArray, out₂::AbstractAr
     m₂ = zero(eltype(mag))
     @inbounds for i in CartesianIndices(mag)
         r, c = i.I
-        d₁ = g₁[i]
-        d₂ = g₂[i]
+        d₁ = gray(g₁[i])
+        d₂ = gray(g₂[i])
         mc = mag[i]
         if mc < threshold || mc == 0 || isnan(mc)
             out₁[r,c] = zero(eltype(mag))


### PR DESCRIPTION
Fixes https://discourse.julialang.org/t/imageedgedetection-the-basic-usage-example-will-not-compile/68628

I'm not quite sure what happened, but perhaps #20 was run against an older version of ColorVectorSpace? Or perhaps we had a breaking release sometime during CVS 0.9.x? But I think the change to "poisoning" semantics for color arithmetic occurred with CVS 0.9.0 and that is likely what triggered this change.